### PR TITLE
add missing exec call

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,4 +17,4 @@ if [ ! -d .venv ]; then
 	uv venv --python=3.12
 fi
 uv pip sync requirements.txt
-.venv/bin/python src/main.py $@
+exec .venv/bin/python src/main.py $@


### PR DESCRIPTION
## What changed
- add `exec` to run.sh
## Why
Subprocess signal handling